### PR TITLE
adding support for cloudwatch monitoring and ecr image use

### DIFF
--- a/cloud-init.yaml
+++ b/cloud-init.yaml
@@ -2,7 +2,7 @@
 write_files:
   - path: /root/conf/enabled_plugins
     content: |
-        [rabbitmq_management].
+        [prometheus_rabbitmq_exporter,rabbitmq_management].
   - path: /root/conf/rabbitmq.config
     content: |
         [ { rabbit, [
@@ -69,7 +69,8 @@ runcmd:
   - service docker start
   - chkconfig docker on
   - usermod -a -G docker ec2-user
-  - docker run -d --name rabbitmq --hostname $HOSTNAME -p 4369:4369 -p 5672:5672 -p 15672:15672 -p 25672:25672 -e RABBITMQ_ERLANG_COOKIE='${secret_cookie}' -v /root/data:/var/lib/rabbitmq -v /root/conf/:/etc/rabbitmq -v /root/bin:/tmp/bin rabbitmq:3-management
+  - $(aws ecr get-login --no-include-email --region ${region} --registry-ids ${ecr_registry_id})
+  - docker run -d --name rabbitmq --hostname $HOSTNAME --log-driver=awslogs --log-opt awslogs-region=${region} --log-opt awslogs-group=${cw_log_group} -p 4369:4369 -p 5672:5672 -p 15672:15672 -p 25672:25672 -e RABBITMQ_ERLANG_COOKIE='${secret_cookie}' -v /root/data:/var/lib/rabbitmq -v /root/conf/:/etc/rabbitmq -v /root/bin:/tmp/bin ${rabbitmq_image}
   - sleep 1
   - docker exec rabbitmq bash /tmp/bin/join_cluster.sh $(bash /root/find_hosts.sh)
   - sleep 1

--- a/outputs.tf
+++ b/outputs.tf
@@ -16,4 +16,3 @@ output "secret_cookie" {
   value     = random_string.secret_cookie.result
   sensitive = true
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -54,3 +54,10 @@ variable "instance_volume_iops" {
   default = "0"
 }
 
+variable "rabbitmq_image" {
+    type = string
+}
+
+variable "ecr_registry_id" {
+    type = string
+}


### PR DESCRIPTION
RabbitMQ installation will now support prometheus scraper endpoint for metrics as well as shuttling all rabbit logs to cloudwatch.